### PR TITLE
Add tags input box automation - Fixes #1

### DIFF
--- a/tests/pages/tags-input-page.ts
+++ b/tests/pages/tags-input-page.ts
@@ -1,0 +1,24 @@
+import { Page } from '@playwright/test';
+
+export class TagsInputPage {
+    constructor(private page: Page) {}
+
+    async navigate() {
+        await this.page.goto('https://qaplayground.dev/apps/tags-input-box/');
+    }
+
+    async addTag(tagName: string) {
+        await this.page.getByRole('textbox').fill(tagName);
+        await this.page.getByRole('textbox').press('Enter');
+    }
+
+    async getTagsList() {
+        const tags = await this.page.locator('li').allTextContents();
+        return tags.map(tag => tag.trim());
+    }
+
+    async getRemainingTagsCount() {
+        const countText = await this.page.locator('p').filter({ hasText: 'tags are remaining' }).textContent();
+        return parseInt(countText?.split(' ')[0] || '0');
+    }
+}

--- a/tests/tags-input.spec.ts
+++ b/tests/tags-input.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import { TagsInputPage } from './pages/tags-input-page';
+
+test.describe('Tags Input Box', () => {
+    let tagsInputPage: TagsInputPage;
+
+    test.beforeEach(async ({ page }) => {
+        tagsInputPage = new TagsInputPage(page);
+        await tagsInputPage.navigate();
+    });
+
+    test('should add a new tag and verify count', async () => {
+        // Get initial count
+        const initialCount = await tagsInputPage.getRemainingTagsCount();
+        
+        // Add a new tag
+        const newTag = 'playwright';
+        await tagsInputPage.addTag(newTag);
+        
+        // Verify tag was added
+        const tags = await tagsInputPage.getTagsList();
+        expect(tags).toContain(newTag);
+        
+        // Verify count decreased by 1
+        const newCount = await tagsInputPage.getRemainingTagsCount();
+        expect(newCount).toBe(initialCount - 1);
+    });
+});


### PR DESCRIPTION
This PR implements the automated tests for the Tags Input Box functionality as requested in Issue #1.

## Changes Made
- Created `TagsInputPage` page object with methods for interacting with the tags input box
- Added test file `tags-input.spec.ts` that verifies:
  - Adding a new tag
  - Verifying the tag was added successfully
  - Verifying the remaining tags count is updated correctly

## Test Implementation Details
- Uses Page Object Model pattern for better maintainability
- Implements all required steps from Issue #1
- Includes proper assertions for tag presence and count validation

## Manual Testing Steps Performed
1. Navigated to https://qaplayground.dev/apps/tags-input-box/
2. Added a new tag ("playwright")
3. Verified tag was added to the list
4. Verified the remaining tags count decreased by 1

## Locators Used
- Textbox: `page.getByRole('textbox')`
- Tags list: `page.locator('li')`
- Remaining count: `page.locator('p').filter({ hasText: 'tags are remaining' })`

Closes #1